### PR TITLE
add common usage pattern to SDK

### DIFF
--- a/examples/speech_summarized.py
+++ b/examples/speech_summarized.py
@@ -1,48 +1,4 @@
-from slashml import SpeechToText, TextSummarization
-import time
-
-
-def speech_to_text(uploaded_audio_url, service_provider, api_key):
-    # Initialize model
-    model = SpeechToText(api_key=api_key)
-
-    # Submit transcription request
-    job = model.transcribe(uploaded_audio_url, service_provider=service_provider)
-
-    assert job.status != "ERROR", f"{job}"
-    print(f"Job ID: {job.id}")
-
-    # check job status
-    response = model.status(job.id, service_provider=service_provider)
-
-    while response.status == "IN_PROGRESS":
-        time.sleep(30)
-        response = model.status(job.id, service_provider=service_provider)
-        print(f"Response = {response}. Retrying in 30 seconds")
-
-    return response
-
-
-def summarize(text, service_provider, api_key):
-    # Initialize model
-    model = TextSummarization(api_key=api_key)
-
-    # Submit request
-    job = model.summarize(text=text, service_provider=service_provider)
-
-    assert job.status != "ERROR", f"{job}"
-    print(f"Job ID: {job.id}")
-
-    # Check job status
-    response = model.status(job.id, service_provider=service_provider)
-
-    # Keep checking job status until the task is complete
-    while response.status == "PENDING":
-        print(f"Response = {response}. Retrying in 30 seconds")
-        time.sleep(30)
-        response = model.status(job.id, service_provider=service_provider)
-
-    return response
+from slashml import SpeechToText, TextSummarization, services
 
 
 # Replace `API_KEY` with your SlasML API token. This example still runs without
@@ -57,13 +13,19 @@ uploaded_url = (
     "https://slashml.s3.ca-central-1.amazonaws.com/fda70f6a-6057-4541-adf1-2cf4f4182929"
 )
 
+ # Convert audio to text
+response_speech_to_text = services.speech_to_text(
+    uploaded_url, service_provider_speech_to_text, API_KEY
+)
 
-response_speech_to_text = speech_to_text(uploaded_url, service_provider_speech_to_text, API_KEY)
-
+# Extract text from API response
 transcribed_text = response_speech_to_text.transcription_data.transcription
-print (f"Transcribed Text = {transcribed_text}")
+print(f"Transcribed Text = {transcribed_text}")
 
-response_summarize = summarize(transcribed_text, service_provider_summarize, API_KEY)
+# Summarize text
+response_summarize = services.summarize_text(
+    transcribed_text, service_provider_summarize, API_KEY
+)
 summary = response_summarize.summarization_data
 
-print (f"Summarized Text = {summary}")
+print(f"Summarized Text = {summary}")

--- a/examples/speech_to_text.py
+++ b/examples/speech_to_text.py
@@ -1,33 +1,4 @@
-from slashml import SpeechToText
-import time
-
-
-def speech_to_text(audio_filepath, service_provider, api_key):
-    # Initialize model
-    model = SpeechToText(api_key=api_key)
-
-    # Upload audio
-    uploaded_file = model.upload_audio(audio_filepath)
-    print(f"file uploaded: {uploaded_file}")
-
-    # Submit transcription request
-    job = model.transcribe(
-        uploaded_file["upload_url"], service_provider=service_provider
-    )
-
-    assert job.status != "ERROR", f"{job}"
-    print(f"Job ID: {job.id}")
-
-    # check job status
-    response = model.status(job.id, service_provider=service_provider)
-
-    while response.status == "IN_PROGRESS":
-        print(f"Response = {response}. Retrying in 30 seconds")
-        time.sleep(30)
-        response = model.status(job.id, service_provider=service_provider)
-
-    return response
-
+from slashml import SpeechToText, services
 
 # Replace `API_KEY` with your SlasML API token. This example still runs without
 # the API token but usage will be limited
@@ -39,8 +10,7 @@ audio_filepath = "test.mp3"
 print(f"Available providers: {SpeechToText.ServiceProvider.choices()}")
 print(f"Selected provider: {service_provider}")
 
-
-response = speech_to_text(
+response = services.speech_to_text(
     audio_filepath=audio_filepath, service_provider=service_provider, api_key=API_KEY
 )
 print(f"{response}\n\nTranscription = {response.transcription_data.transcription}")

--- a/examples/summarize.py
+++ b/examples/summarize.py
@@ -1,31 +1,8 @@
-from slashml import TextSummarization
-import time
-
-def summarize(text, service_provider, api_key):
-    # Initialize model
-    model = TextSummarization(api_key=api_key)
-
-    # Submit request
-    job = model.summarize(text=text, service_provider=service_provider)
-
-    assert job.status != "ERROR", f"{job}"
-    print(f"Job ID: {job.id}")
-
-    # Check job status
-    response = model.status(job.id, service_provider=service_provider)
-
-    # Keep checking job status until the task is complete
-    while response.status == "PENDING":
-        print(f"Response = {response}. Retrying in 30 seconds")
-        time.sleep(30)
-        response = model.status(job.id, service_provider=service_provider)
-
-    return response
-
+from slashml import TextSummarization, services
 
 # Replace `API_KEY` with your SlasML API token. This example still runs without
 # the API token but usage will be limited
-API_KEY = "b503d137d229fdd4085f59e9ea06ac95d2706182"
+API_KEY = None
 service_provider = TextSummarization.ServiceProvider.OPENAI
 input_text = """A good writer doesn't just think, and then write down what he thought, as a sort of transcript. A good writer will almost always discover new things in the process of writing. And there is, as far as I know, no substitute for this kind of discovery. Talking about your ideas with other people is a good way to develop them. But even after doing this, you'll find you still discover new things when you sit down to write. There is a kind of thinking that can only be done by writing."""
 
@@ -33,5 +10,6 @@ input_text = """A good writer doesn't just think, and then write down what he th
 print(f"Available providers: {TextSummarization.ServiceProvider.choices()}")
 print(f"Selected provider: {service_provider}")
 
-response = summarize(text=input_text, service_provider=service_provider, api_key=API_KEY)
+# Summarize text
+response = services.summarize_text(text=input_text, service_provider=service_provider, api_key=API_KEY)
 print(f"{response}\n\nSummary = {response.summarization_data}")

--- a/slashml/services.py
+++ b/slashml/services.py
@@ -1,0 +1,51 @@
+from slashml import TextSummarization, SpeechToText
+import time
+
+
+def summarize_text(text, service_provider, api_key):
+    # Initialize model
+    model = TextSummarization(api_key=api_key)
+
+    # Submit request
+    job = model.summarize(text=text, service_provider=service_provider)
+
+    assert job.status != "ERROR", f"{job}"
+    print(f"Job ID: {job.id}")
+
+    # Check job status
+    response = model.status(job.id, service_provider=service_provider)
+
+    # Keep checking job status until the task is complete
+    while response.status == "IN_PROGRESS":
+        print(f"Response = {response}. Retrying in 30 seconds")
+        time.sleep(30)
+        response = model.status(job.id, service_provider=service_provider)
+
+    return response
+
+
+def speech_to_text(audio_filepath, service_provider, api_key):
+    # Initialize model
+    model = SpeechToText(api_key=api_key)
+
+    # Upload audio
+    uploaded_file = model.upload_audio(audio_filepath)
+    print(f"file uploaded: {uploaded_file}")
+
+    # Submit transcription request
+    job = model.transcribe(
+        uploaded_file["upload_url"], service_provider=service_provider
+    )
+
+    assert job.status != "ERROR", f"{job}"
+    print(f"Job ID: {job.id}")
+
+    # check job status
+    response = model.status(job.id, service_provider=service_provider)
+
+    while response.status == "IN_PROGRESS":
+        print(f"Response = {response}. Retrying in 30 seconds")
+        time.sleep(30)
+        response = model.status(job.id, service_provider=service_provider)
+
+    return response

--- a/slashml/text_summarization.py
+++ b/slashml/text_summarization.py
@@ -25,3 +25,4 @@ class TextSummarization:
 
     def status(self, job_id: str, service_provider: ServiceProvider):
         return getTaskStatus(self._base_url, self._headers, job_id, service_provider)
+        


### PR DESCRIPTION
!!!DONT MERGE!!!

Added two methods to SDK that are common usage pattern for the existing APIs.
- `summarize_text`
- `speech_to_text`

This is used in `examples` and also in `dash-demo`. I for-see this being a common usage pattern so it makes sense to include it in the code SDK package. I am not sure about naming here, so let's discuss before merging.